### PR TITLE
add is_write_index=True for aliases in to index-template

### DIFF
--- a/sentry_nodestore_elastic/backend.py
+++ b/sentry_nodestore_elastic/backend.py
@@ -81,7 +81,9 @@ class ElasticNodeStorage(NodeStorage):
                         }
                     },
                     "aliases": {
-                        self.alias_name: {}
+                        self.alias_name: {
+                            "is_write_index": True
+                        }
                     }
                 }
             )


### PR DESCRIPTION
Hello!
I had testing your nodestore driver and found that elastic index template doesn't working in elastic 8.10+ as expected.
Sentry got CRITICAL error with error code 404 - it cannot find any aliases for nodestrore.
In sentry web we had problem with events in Details on issue page. Sentry couldn't load events.

This request fix the issue.

P.S.
Many thanks for your attention!
P.S.S.
We tested driver for Sentry 23+ it was working fine.